### PR TITLE
fix: Exception Handler not convert ApiResponse to JsonResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ public function register()
 {
     $this->renderable(function (Throwable $e, $request) {
         if ($request->wantsJson() || $request->is('*api*')) {
-            return ApiExceptionHandler::renderAsApiResponse($e);
+            return ApiExceptionHandler::renderAsApiResponse($e, $request);
         }
     });
 }
@@ -146,7 +146,7 @@ public function register()
 public function render($request, Throwable $exception)
 {
     if ($request->wantsJson() || $request->is('*api*')) {
-        return ApiExceptionHandler::renderAsApiResponse($exception);
+        return ApiExceptionHandler::renderAsApiResponse($exception, $request);
     }
 
     return parent::render($request, $exception);

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -24,7 +24,7 @@ class ExceptionHandler
         $request = $request ?? request();
 
         if ($e instanceof ApiException) {
-            return $e->render();
+            return $e->render()->toResponse($request);
         }
 
         try {


### PR DESCRIPTION
This PR is trying to fix bug when `ApiException` has been thrown but not converted to `JsonResponse`. This solution not optimal, more appropriate solution is #15 but it will change the return type of ApiException `getResponse` method. That will break the v1. So this PR is aim to support v1. This is the best we can do. See you on v2 soon :)